### PR TITLE
Files.Associations doesn't work for T4 support.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,7 @@ export function activate(context: vscode.ExtensionContext) {
 	}
 
 	function updateDecorations() {
-		if (!activeEditor || !fileTypeSupported(activeEditor)) {
+		if (!activeEditor || !isT4File(activeEditor)) {
 			return;
 		}
 		const regEx = /(<#@|<#\+|<#=|<#|#>)+/g;
@@ -85,7 +85,7 @@ export function activate(context: vscode.ExtensionContext) {
 		activeEditor.setDecorations(codeBlockDecorationType, blocks);
 	}
 
-	function fileTypeSupported(editor: vscode.TextEditor): boolean{
-		return editor.document.fileName.endsWith(".tt");
+	function isT4File(editor: vscode.TextEditor): boolean{
+		return editor.document.languageId == "t4";
 	}
 }	


### PR DESCRIPTION
First, let me say thanks for the great extension! It's been very helpful.

This PR was made to fix a small bug that prevents the extension from working with file extensions other than ".tt". I work with some T4 files that don't use the ".tt" file extension and tried setting them to be recognized as "t4" via the following vscode setting:
```
    "files.associations": {
        "*.extension" : "t4",
    },
```
Instead of checking that the document ends with ".tt" the extension now checks to see if VSCode recognizes the current document's language as "t4".