### PR TITLE
Recognize .ttinclude file extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # T4 Support
 
-Very basic language support for T4 Text Templates (.tt) files.
+Very basic language support for T4 Text Templates (.tt, .ttinclude) files.
 
 For more information about using T4 templates, see [Code Generation and T4 Text Templates](https://docs.microsoft.com/en-us/visualstudio/modeling/code-generation-and-t4-text-templates).
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
                     "tt"
                 ],
                 "extensions": [
-                    ".tt"
+                    ".tt",
+                    ".ttinclude"
                 ],
                 "configuration": "./language-configuration.json"
             }


### PR DESCRIPTION
This is a file extension that's [conventionally used](https://docs.microsoft.com/en-us/visualstudio/modeling/guidelines-for-writing-t4-text-templates?view=vs-2019#guidelines-for-all-t4-templates) to indicate that a T4 file is only intended to be `include`d in `.tt` files, as opposed to being processed directly. It seems worth recognizing this out of the box.