### PR TITLE
Recognize .t4 file extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
                     "tt"
                 ],
                 "extensions": [
+                    ".t4",
                     ".tt",
                     ".ttinclude"
                 ],


### PR DESCRIPTION
This is a common tactic used to prevent Visual Studio from automatically transforming the templates.